### PR TITLE
Added Generating Slugs with Random Numbers

### DIFF
--- a/slug.go
+++ b/slug.go
@@ -7,9 +7,12 @@ package slug
 
 import (
 	"bytes"
+	"math/rand"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gosimple/unidecode"
 )
@@ -185,4 +188,23 @@ func IsSlug(text string) bool {
 		}
 	}
 	return true
+}
+
+// MakeWithRandomNumber returns a slug generated from the provided string
+// with a random 3-digit number appended at the end. Will use "en" as language
+// substitution.
+func MakeWithRandomNumber(s string) (slug string) {
+
+	// Create the slug from the provided string
+	slug = Make(s)
+
+	// Generate a random 3-digit number
+	rand.Seed(time.Now().UnixNano())
+	randomNumber := rand.Intn(900) + 100
+
+	// Append the random number to the slug
+	randomNumberStr := strconv.Itoa(randomNumber)
+	slug += "-" + randomNumberStr
+
+	return slug
 }

--- a/slug_test.go
+++ b/slug_test.go
@@ -6,6 +6,8 @@
 package slug
 
 import (
+	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -502,4 +504,24 @@ func BenchmarkIsSlugLong(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		IsSlug(longStr)
 	}
+}
+
+func TestSlugMakeWidthRandomNumber(t *testing.T) {
+
+	in := "Hello World"
+
+	result := MakeWithRandomNumber(in)
+
+	expectedPrefix := Make(in) + "-"
+	if !strings.HasPrefix(result, expectedPrefix) {
+		t.Errorf("Expected prefix %s, but got prefix %s", expectedPrefix, result)
+
+	}
+
+	randomNumberStr := strings.TrimPrefix(result, expectedPrefix)
+	randomNumber, err := strconv.Atoi(randomNumberStr)
+	if err != nil || randomNumber < 100 || randomNumber > 999 {
+		t.Errorf("Random number is not within the expected range: %s", randomNumberStr)
+	}
+
 }


### PR DESCRIPTION
This pull request adds a new function named "MakeWithRandomNumber" to the project. This function allows users to automatically generate a slug from the provided text-based input and append a random 3-digit number to the end of the slug. This provides developers with an easy way to create unique and randomized slugs.

The new function is based on the existing slug generation logic of the project and uses the "en" language. It also uses a reliable seed value for generating random numbers, ensuring that you get different slugs every time you run it.